### PR TITLE
fix: emit ResponseStream for CLI-generated SDKs

### DIFF
--- a/src/libs/AutoSDK.CLI/Commands/GenerateCommand.cs
+++ b/src/libs/AutoSDK.CLI/Commands/GenerateCommand.cs
@@ -270,6 +270,9 @@ internal sealed class GenerateCommand : Command
             .Concat([Sources.Polyfills(settings)])
             .Concat([Sources.Exceptions(settings)])
             .Concat([Sources.PathBuilder(settings)])
+            .Concat(data.Methods.Any(static x => x.RawStream)
+                ? [Sources.ResponseStream(data.Converters.Settings)]
+                : [])
             .Concat([Sources.UnixTimestampJsonConverter(settings)])
             .Where(x => !x.IsEmpty)
             .ToArray();

--- a/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
+++ b/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
@@ -5,24 +5,13 @@ namespace AutoSDK.IntegrationTests;
 [TestClass]
 public class CliTests
 {
-    // [DataTestMethod]
-    // [DataRow("github.yaml")]
-    // [DataRow("ipinfo.yaml")]
-    // [DataRow("langsmith.json")]
-    // [DataRow("ollama.yaml")]
-    // [DataRow("openai.yaml")]
-    // [DataRow("petstore.yaml")]
-    // [DataRow("replicate.json")]
-    // [DataRow("huggingface.yaml")]
-    // [DataRow("ai21.json")]
-    // [DataRow("cohere.yaml")]
-    // [DataRow("special-cases.yaml")]
-    // [DataRow("twitch.json")]
-    // [DataRow("https://dedoose-rest-api.onrender.com/swagger/v1/swagger.json")]
-    // [DataRow("together.yaml")]
-    // [DataRow("mystic.yaml")]
-    // [DataRow("heygen.yaml")]
-    public async Task Generate(string spec)
+    [TestMethod]
+    public async Task Generate_ElevenLabsStreamingSdk()
+    {
+        await GenerateAsync("elevenlabs.json");
+    }
+
+    private static async Task GenerateAsync(string spec)
     {
         var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         try
@@ -46,6 +35,9 @@ public class CliTests
             Directory.EnumerateFiles(tempDirectory, "*", SearchOption.AllDirectories)
                 .Should()
                 .NotBeEmpty();
+            Directory.EnumerateFiles(tempDirectory, "*.ResponseStream.g.cs", SearchOption.AllDirectories)
+                .Should()
+                .ContainSingle();
 
             await File.WriteAllTextAsync(Path.Combine(tempDirectory, "Oag.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating ResponseStream source files when SDK methods include RawStream functionality, enabling enhanced streaming capabilities.

* **Tests**
  * Refactored integration tests to include dedicated streaming SDK validation with explicit response stream file generation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->