### PR TITLE
fix: sanitize dangling OpenAPI discriminators

### DIFF
--- a/src/libs/AutoSDK.CLI/AutoSDK.CLI.csproj
+++ b/src/libs/AutoSDK.CLI/AutoSDK.CLI.csproj
@@ -26,6 +26,7 @@
     <EmbeddedResource Remove="Resources\obj\**" />
     <EmbeddedResource Remove="Resources\bin\**" />
     <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.3" />
     <PackageReference Include="Firecrawl" Version="1.1.1" />
     <PackageReference Include="tryAGI.OpenAI" Version="4.2.0" />

--- a/src/libs/AutoSDK/Extensions/OpenApiExtensions.cs
+++ b/src/libs/AutoSDK/Extensions/OpenApiExtensions.cs
@@ -66,6 +66,7 @@ public static class OpenApiExtensions
         }
 
         openApiDocument.SanitizeNumericConstraints();
+        openApiDocument.SanitizeDiscriminators();
 
         return openApiDocument;
     }
@@ -133,6 +134,73 @@ public static class OpenApiExtensions
         }
         SanitizeSchemaNumericConstraints(concreteSchema.Items);
         SanitizeSchemaNumericConstraints(concreteSchema.AdditionalProperties);
+    }
+
+    public static void SanitizeDiscriminators(this OpenApiDocument document)
+    {
+        document = document ?? throw new ArgumentNullException(nameof(document));
+
+        var componentIds = new HashSet<string>(
+            document.Components?.Schemas?.Keys ?? Enumerable.Empty<string>(),
+            StringComparer.Ordinal);
+
+        foreach (var schema in document.Components?.Schemas?.Values ?? Enumerable.Empty<IOpenApiSchema>())
+        {
+            SanitizeSchemaDiscriminators(schema, componentIds);
+        }
+    }
+
+    private static void SanitizeSchemaDiscriminators(
+        IOpenApiSchema? schema,
+        ISet<string> componentIds)
+    {
+        if (schema is not OpenApiSchema concreteSchema)
+        {
+            return;
+        }
+
+        if (concreteSchema.Discriminator?.Mapping is { Count: > 0 } mapping)
+        {
+            var validMappings = mapping
+                .Where(x => x.Value.Reference?.Id is { } id && componentIds.Contains(id))
+                .ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal);
+            var hasCompositionChildren =
+                (concreteSchema.OneOf?.Count ?? 0) > 0 ||
+                (concreteSchema.AnyOf?.Count ?? 0) > 0 ||
+                (concreteSchema.AllOf?.Count ?? 0) > 0;
+
+            if (validMappings.Count == 0 && !hasCompositionChildren)
+            {
+                concreteSchema.Discriminator = null;
+            }
+            else if (validMappings.Count > 0 && validMappings.Count != mapping.Count)
+            {
+                concreteSchema.Discriminator = new OpenApiDiscriminator
+                {
+                    PropertyName = concreteSchema.Discriminator.PropertyName,
+                    Mapping = validMappings,
+                };
+            }
+        }
+
+        foreach (var property in concreteSchema.Properties?.Values ?? Enumerable.Empty<IOpenApiSchema>())
+        {
+            SanitizeSchemaDiscriminators(property, componentIds);
+        }
+        foreach (var child in concreteSchema.AnyOf ?? Enumerable.Empty<IOpenApiSchema>())
+        {
+            SanitizeSchemaDiscriminators(child, componentIds);
+        }
+        foreach (var child in concreteSchema.OneOf ?? Enumerable.Empty<IOpenApiSchema>())
+        {
+            SanitizeSchemaDiscriminators(child, componentIds);
+        }
+        foreach (var child in concreteSchema.AllOf ?? Enumerable.Empty<IOpenApiSchema>())
+        {
+            SanitizeSchemaDiscriminators(child, componentIds);
+        }
+        SanitizeSchemaDiscriminators(concreteSchema.Items, componentIds);
+        SanitizeSchemaDiscriminators(concreteSchema.AdditionalProperties, componentIds);
     }
 
     private static bool IsOutOfRange(string? value, decimal bound, bool isMin)

--- a/src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj
+++ b/src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj
@@ -29,7 +29,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.3" />
     <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 

--- a/src/tests/AutoSDK.UnitTests/Tests.SanitizeDiscriminators.cs
+++ b/src/tests/AutoSDK.UnitTests/Tests.SanitizeDiscriminators.cs
@@ -1,0 +1,82 @@
+using AutoSDK.Extensions;
+using Microsoft.OpenApi;
+
+namespace AutoSDK.UnitTests;
+
+[TestClass]
+public class SanitizeDiscriminatorsTests
+{
+    [TestMethod]
+    public void RemoveDiscriminator_WhenAllMappingsAreDanglingAndSchemaHasNoComposition()
+    {
+        var document = new OpenApiDocument
+        {
+            Components = new OpenApiComponents
+            {
+                Schemas = new Dictionary<string, IOpenApiSchema>
+                {
+                    ["TruncationStrategy"] = new OpenApiSchema
+                    {
+                        Type = JsonSchemaType.Object,
+                        Discriminator = new OpenApiDiscriminator
+                        {
+                            PropertyName = "type",
+                            Mapping = new Dictionary<string, OpenApiSchemaReference>
+                            {
+                                ["auto"] = new("TruncationStrategyAuto", null, string.Empty),
+                                ["none"] = new("TruncationStrategyNone", null, string.Empty),
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        document.SanitizeDiscriminators();
+
+        var schema = (OpenApiSchema)document.Components.Schemas["TruncationStrategy"];
+        Assert.IsNull(schema.Discriminator);
+    }
+
+    [TestMethod]
+    public void TrimDanglingMappings_WhenSomeMappingsResolve()
+    {
+        var document = new OpenApiDocument
+        {
+            Components = new OpenApiComponents
+            {
+                Schemas = new Dictionary<string, IOpenApiSchema>
+                {
+                    ["Vehicle"] = new OpenApiSchema
+                    {
+                        OneOf =
+                        [
+                            new OpenApiSchemaReference("Car", null, string.Empty),
+                        ],
+                        Discriminator = new OpenApiDiscriminator
+                        {
+                            PropertyName = "kind",
+                            Mapping = new Dictionary<string, OpenApiSchemaReference>
+                            {
+                                ["car"] = new("Car", null, string.Empty),
+                                ["boat"] = new("Boat", null, string.Empty),
+                            },
+                        },
+                    },
+                    ["Car"] = new OpenApiSchema
+                    {
+                        Type = JsonSchemaType.Object,
+                    },
+                },
+            },
+        };
+
+        document.SanitizeDiscriminators();
+
+        var schema = (OpenApiSchema)document.Components.Schemas["Vehicle"];
+        schema.Discriminator.Should().NotBeNull();
+        schema.Discriminator!.PropertyName.Should().Be("kind");
+        schema.Discriminator.Mapping.Should().ContainSingle();
+        schema.Discriminator.Mapping.Keys.Should().Contain("car");
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI discriminator sanitization to automatically remove or trim invalid discriminator mappings based on component references, improving document integrity.
  * Added support for reading OpenAPI YAML format files.

* **Tests**
  * Added unit tests to verify discriminator sanitization behavior for various mapping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->