### PR TITLE
fix: support CPM restore for source generators

### DIFF
--- a/src/libs/AutoSDK.SourceGenerators/AutoSDK.SourceGenerators.props
+++ b/src/libs/AutoSDK.SourceGenerators/AutoSDK.SourceGenerators.props
@@ -137,7 +137,19 @@
 <!--        MetadataName="%(CompilerVisibleProperty.Identity)" />-->
 <!--  </ItemGroup>-->
 
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+  <PropertyGroup>
+    <_AutoSDKRequiresServerSentEvents Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</_AutoSDKRequiresServerSentEvents>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_AutoSDKRequiresServerSentEvents)' == 'true' and '$(ManagePackageVersionsCentrally)' == 'true' and '@(PackageVersion->WithMetadataValue('Identity', 'System.Net.ServerSentEvents'))' == ''">
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(_AutoSDKRequiresServerSentEvents)' == 'true' and '$(ManagePackageVersionsCentrally)' == 'true'">
+    <PackageReference Include="System.Net.ServerSentEvents" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(_AutoSDKRequiresServerSentEvents)' == 'true' and '$(ManagePackageVersionsCentrally)' != 'true'">
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
+++ b/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
@@ -2156,6 +2156,70 @@ components:
         }
     }
 
+    [TestMethod]
+    public async Task SourceGeneratorsProps_Restore_WithCentralPackageManagement()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            Directory.CreateDirectory(tempDirectory);
+
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var repositoryDirectory = Path.GetFullPath(Path.Combine(currentDirectory, "../../../../../.."));
+            var propsPath = Path.Combine(
+                    repositoryDirectory,
+                    "src",
+                    "libs",
+                    "AutoSDK.SourceGenerators",
+                    "AutoSDK.SourceGenerators.props")
+                .Replace('\\', '/');
+            var escapedPropsPath = System.Security.SecurityElement.Escape(propsPath)!;
+
+            await File.WriteAllTextAsync(
+                Path.Combine(tempDirectory, "Directory.Packages.props"),
+                """
+                <Project>
+                  <PropertyGroup>
+                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(
+                Path.Combine(tempDirectory, "Test.csproj"),
+                $$"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <Import Project="{{escapedPropsPath}}" />
+
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var restoreResult = await RunDotnetAsync(
+                tempDirectory,
+                "restore",
+                "--disable-build-servers",
+                Path.Combine(tempDirectory, "Test.csproj"));
+
+            Console.WriteLine(restoreResult.StandardOutput);
+            Console.WriteLine(restoreResult.StandardError);
+
+            restoreResult.ExitCode.Should().Be(0);
+            restoreResult.StandardError.Should().NotContain("NU1008");
+
+            var assetsPath = Path.Combine(tempDirectory, "obj", "project.assets.json");
+            File.Exists(assetsPath).Should().BeTrue();
+
+            var projectAssets = await File.ReadAllTextAsync(assetsPath);
+            projectAssets.Should().Contain("System.Net.ServerSentEvents");
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDirectory);
+        }
+    }
+
     private static async Task<(int ExitCode, string StandardOutput, string StandardError)> RunDotnetAsync(
         string workingDirectory,
         params string[] arguments)


### PR DESCRIPTION
## Summary
- make `AutoSDK.SourceGenerators.props` compatible with Central Package Management when `System.Net.ServerSentEvents` is needed on pre-`net10.0` targets
- keep the existing non-CPM behavior while letting consumer-defined central package versions win
- add a regression test that restores a temporary CPM project importing the real props file

## Root Cause
The transitive props file emitted a versioned `<PackageReference>` for `System.Net.ServerSentEvents`. NuGet rejects that shape under `ManagePackageVersionsCentrally=true` with `NU1008`, because the version must come from a `PackageVersion` item instead.

## Validation
- `dotnet test src/tests/AutoSDK.IntegrationTests.Cli/AutoSDK.IntegrationTests.Cli.csproj --filter "FullyQualifiedName~SourceGeneratorsProps_Restore_WithCentralPackageManagement"`
- manual non-CPM restore importing the props file
- manual CPM restore with a consumer-defined central `System.Net.ServerSentEvents` version
