### PR TITLE
chore: refresh test and tooling package versions

### DIFF
--- a/src/libs/AutoSDK.CLI/Resources/src_libs_Directory.Build.props
+++ b/src/libs/AutoSDK.CLI/Resources/src_libs_Directory.Build.props
@@ -33,14 +33,14 @@
   </PropertyGroup>
 
   <ItemGroup Label="Versioning">
-    <PackageReference Include="MinVer" Version="6.0.0">
+    <PackageReference Include="MinVer" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Label="Source Link">
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25">
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/libs/AutoSDK.CLI/Resources/src_tests_IntegrationTests_$SolutionName$.IntegrationTests.csproj
+++ b/src/libs/AutoSDK.CLI/Resources/src_tests_IntegrationTests_$SolutionName$.IntegrationTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.1.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1">
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/libs/AutoSDK.SourceGenerators/AutoSDK.SourceGenerators.props
+++ b/src/libs/AutoSDK.SourceGenerators/AutoSDK.SourceGenerators.props
@@ -142,7 +142,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_AutoSDKRequiresServerSentEvents)' == 'true' and '$(ManagePackageVersionsCentrally)' == 'true' and '@(PackageVersion->WithMetadataValue('Identity', 'System.Net.ServerSentEvents'))' == ''">
-    <PackageVersion Include="System.Net.ServerSentEvents" Version="9.0.0" />
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(_AutoSDKRequiresServerSentEvents)' == 'true' and '$(ManagePackageVersionsCentrally)' == 'true'">
@@ -150,7 +150,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(_AutoSDKRequiresServerSentEvents)' == 'true' and '$(ManagePackageVersionsCentrally)' != 'true'">
-    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.0" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/AutoSDK.IntegrationTests.Cli/AutoSDK.IntegrationTests.Cli.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.Cli/AutoSDK.IntegrationTests.Cli.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup Label="Base packages">
     <PackageReference Include="CliWrap" Version="3.10.1" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.2">
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
+++ b/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
@@ -2212,7 +2212,7 @@ components:
             File.Exists(assetsPath).Should().BeTrue();
 
             var projectAssets = await File.ReadAllTextAsync(assetsPath);
-            projectAssets.Should().Contain("System.Net.ServerSentEvents");
+            projectAssets.Should().Contain("System.Net.ServerSentEvents/10.0.5");
         }
         finally
         {

--- a/src/tests/AutoSDK.IntegrationTests.IpInfo.Data/AutoSDK.IntegrationTests.IpInfo.Data.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.IpInfo.Data/AutoSDK.IntegrationTests.IpInfo.Data.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.16" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.16" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/AutoSDK.IntegrationTests.IpInfo/AutoSDK.IntegrationTests.IpInfo.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.IpInfo/AutoSDK.IntegrationTests.IpInfo.csproj
@@ -25,13 +25,13 @@
   </PropertyGroup>
 
   <ItemGroup Label="Base packages">
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
   </ItemGroup>
 
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="H.Resources.Generator" Version="1.6.0">
+    <PackageReference Include="H.Resources.Generator" Version="1.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.16" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.16" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/AutoSDK.IntegrationTests.Ollama.Models/AutoSDK.IntegrationTests.Ollama.Models.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.Ollama.Models/AutoSDK.IntegrationTests.Ollama.Models.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.23" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/AutoSDK.IntegrationTests.Ollama/AutoSDK.IntegrationTests.Ollama.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.Ollama/AutoSDK.IntegrationTests.Ollama.csproj
@@ -25,13 +25,13 @@
   </PropertyGroup>
 
   <ItemGroup Label="Base packages">
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
   </ItemGroup>
 
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="H.Resources.Generator" Version="1.6.1">
+    <PackageReference Include="H.Resources.Generator" Version="1.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.23" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/AutoSDK.IntegrationTests.OpenAI.Models/AutoSDK.IntegrationTests.OpenAI.Models.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.OpenAI.Models/AutoSDK.IntegrationTests.OpenAI.Models.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.16" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.16" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/AutoSDK.IntegrationTests.OpenAI/AutoSDK.IntegrationTests.OpenAI.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.OpenAI/AutoSDK.IntegrationTests.OpenAI.csproj
@@ -26,13 +26,13 @@
   </PropertyGroup>
 
   <ItemGroup Label="Base packages">
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
   </ItemGroup>
 
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="H.Resources.Generator" Version="1.6.0">
+    <PackageReference Include="H.Resources.Generator" Version="1.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.16" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.16" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/AutoSDK.IntegrationTests.Twitch.Data/AutoSDK.IntegrationTests.Twitch.Data.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.Twitch.Data/AutoSDK.IntegrationTests.Twitch.Data.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.16" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.16" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/AutoSDK.IntegrationTests.Twitch/AutoSDK.IntegrationTests.Twitch.csproj
+++ b/src/tests/AutoSDK.IntegrationTests.Twitch/AutoSDK.IntegrationTests.Twitch.csproj
@@ -25,13 +25,13 @@
   </PropertyGroup>
 
   <ItemGroup Label="Base packages">
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
   </ItemGroup>
 
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="H.Resources.Generator" Version="1.6.0">
+    <PackageReference Include="H.Resources.Generator" Version="1.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.16" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.16" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/AutoSDK.SnapshotTests/AutoSDK.SnapshotTests.csproj
+++ b/src/tests/AutoSDK.SnapshotTests/AutoSDK.SnapshotTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Base packages">
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.2">
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -20,7 +20,7 @@
   <ItemGroup Label="Generator tests packages">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageReference Include="Verify.MSTest" Version="31.13.5" />
+    <PackageReference Include="Verify.MSTest" Version="31.15.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageReference Include="H.Resources.Generator" Version="1.8.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj
+++ b/src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup Label="Base packages">
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.2">
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MSTest" Version="4.1.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageReference Include="Verify.MSTest" Version="31.13.5" />
+    <PackageReference Include="Verify.MSTest" Version="31.15.0" />
   </ItemGroup>
 
   <ItemGroup Label="GlobalUsings">


### PR DESCRIPTION
## Summary
- refresh non-Roslyn, non-OpenAPI test and tooling package versions across the repo
- bump `System.Net.ServerSentEvents` to latest stable `10.0.5` in the source generator props and assert that exact resolved version in the CPM restore regression test
- align CLI scaffolding templates with current repo tooling versions for `GitHubActionsTestLogger`, `MinVer`, and `DotNet.ReproducibleBuilds`

## Updated Packages
- `System.Net.ServerSentEvents` -> `10.0.5`
- `GitHubActionsTestLogger` -> `3.0.3`
- `Microsoft.NET.Test.Sdk` -> `18.3.0`
- `MSTest.TestAdapter` / `MSTest.TestFramework` -> `4.1.0`
- `Verify.MSTest` -> `31.15.0`
- `H.Resources.Generator` -> `1.8.0`
- `System.Collections.Immutable` test pins -> `10.0.5`
- CLI resource template `MinVer` -> `7.0.0`
- CLI resource template `DotNet.ReproducibleBuilds` -> `2.0.2`

## Validation
- `dotnet test src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj`
- `dotnet test src/tests/AutoSDK.IntegrationTests.Cli/AutoSDK.IntegrationTests.Cli.csproj --filter "FullyQualifiedName~SourceGeneratorsProps_Restore_WithCentralPackageManagement"`

## Notes
A representative integration build for `AutoSDK.IntegrationTests.Ollama` still fails on `Microsoft.OpenApi` / `SharpYaml` downgrade conflicts, but that same failure reproduces on a clean `origin/main` worktree. This PR intentionally leaves the Roslyn/OpenAPI stack untouched.
