### PR TITLE
[codex] fix open enum release build nullability

### DIFF
--- a/src/libs/AutoSDK.CSharp/Extensions/OpenApiEnumExtensions.cs
+++ b/src/libs/AutoSDK.CSharp/Extensions/OpenApiEnumExtensions.cs
@@ -53,7 +53,7 @@ public static class OpenApiEnumExtensions
             if (!@enum.TryGetValue(context.Schema.Default.GetString() ?? string.Empty, out var result))
             {
                 return context.TypeData.IsOpenEnum
-                    ? $"{context.TypeData.CSharpTypeWithoutNullability}.FromValue({defaultString.ToCSharpStringLiteral()})"
+                    ? $"{context.TypeData.CSharpTypeWithoutNullability}.FromValue({defaultString!.ToCSharpStringLiteral()})"
                     : string.Empty;
             }
 


### PR DESCRIPTION
## Summary
- fix the nullable-flow violation in `OpenApiEnumExtensions` that only showed up in the multi-targeted release build
- keep the merged open-enum work buildable across `net462` and `netstandard2.0`

## Why
[#262](https://github.com/tryAGI/AutoSDK/pull/262) merged before its failing `Test` workflow finished. This PR is the clean follow-up from `main` containing only the validated release-build fix.

## Validation
- `dotnet build --configuration Release --nologo`
- `dotnet test src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj`
