### PR TITLE
feat(csharp): add request and client option support

### DIFF
--- a/src/libs/AutoSDK.CSharp/Pipeline/CSharpPipeline.cs
+++ b/src/libs/AutoSDK.CSharp/Pipeline/CSharpPipeline.cs
@@ -154,6 +154,7 @@ public static class CSharpPipeline
                     .Concat([Sources.Polyfills(settings, cancellationToken)])
                     .Concat([Sources.Exceptions(settings, cancellationToken)])
                     .Concat([Sources.PathBuilder(settings, cancellationToken)])
+                    .Concat([Sources.OptionsSupport(settings, cancellationToken)])
                     .Concat(!data.Authorizations.IsEmpty
                         ? [Sources.SecuritySupport(settings, cancellationToken)]
                         : [])

--- a/src/libs/AutoSDK.CSharp/Sources/Sources.Clients.cs
+++ b/src/libs/AutoSDK.CSharp/Sources/Sources.Clients.cs
@@ -45,6 +45,9 @@ namespace {client.Settings.Namespace}
 #if DEBUG
             = true;
 #endif
+
+        /// <inheritdoc/>
+        public global::{client.Settings.Namespace}.AutoSDKClientOptions Options {{ get; }}
 {(client.HasOAuth2Support ? $@"
 
         internal global::{client.Settings.Namespace}.{rootClassName}.AutoSDKOAuth2Coordinator AutoSDKOAuth2State {{ get; set; }} = new global::{client.Settings.Namespace}.{rootClassName}.AutoSDKOAuth2Coordinator();" : TrimmedLine)}
@@ -61,7 +64,7 @@ namespace {client.Settings.Namespace}
 
 {(client.Clients.Length != 0 ? "\n" + client.Clients.Select(x => $@"
         {x.Summary.ToXmlDocumentationSummary(level: 8)}
-        public {x.Type.CSharpType} {x.Name} => new {x.Type.CSharpType}(HttpClient, authorizations: Authorizations)
+        public {x.Type.CSharpType} {x.Name} => new {x.Type.CSharpType}(HttpClient, authorizations: Authorizations, options: Options)
         {{
             ReadResponseAsString = ReadResponseAsString,
             {(hasOptions
@@ -84,11 +87,36 @@ namespace {client.Settings.Namespace}
             global::System.Net.Http.HttpClient? httpClient = null,
             global::System.Uri? baseUri = null,
             global::System.Collections.Generic.List<global::{client.GlobalSettings.Namespace}.EndPointAuthorization>? authorizations = null,
+            bool disposeHttpClient = true) : this(
+                httpClient,
+                baseUri,
+                authorizations,
+                options: null,
+                disposeHttpClient: disposeHttpClient)
+        {{
+        }}
+
+        /// <summary>
+        /// Creates a new instance of the {client.ClassName}.
+        /// If no httpClient is provided, a new one will be created.
+        /// If no baseUri is provided, the default baseUri from OpenAPI spec will be used.
+        /// </summary>
+        /// <param name=""httpClient"">The HttpClient instance. If not provided, a new one will be created.</param>
+        /// <param name=""baseUri"">The base URL for the API. If not provided, the default baseUri from OpenAPI spec will be used.</param>
+        /// <param name=""authorizations"">The authorizations to use for the requests.</param>
+        /// <param name=""options"">Client-wide request defaults such as headers, query parameters, retries, and timeout.</param>
+        /// <param name=""disposeHttpClient"">Dispose the HttpClient when the instance is disposed. True by default.</param>
+        public {client.ClassName}(
+            global::System.Net.Http.HttpClient? httpClient = null,
+            global::System.Uri? baseUri = null,
+            global::System.Collections.Generic.List<global::{client.GlobalSettings.Namespace}.EndPointAuthorization>? authorizations = null,
+            global::{client.Settings.Namespace}.AutoSDKClientOptions? options = null,
             bool disposeHttpClient = true)
         {{
             HttpClient = httpClient ?? new global::System.Net.Http.HttpClient();
             HttpClient.BaseAddress ??= baseUri ?? new global::System.Uri(DefaultBaseUrl);
             Authorizations = authorizations ?? new global::System.Collections.Generic.List<global::{client.GlobalSettings.Namespace}.EndPointAuthorization>();
+            Options = options ?? new global::{client.Settings.Namespace}.AutoSDKClientOptions();
             _disposeHttpClient = disposeHttpClient;
 
             Initialized(HttpClient);
@@ -159,6 +187,11 @@ namespace {client.Settings.Namespace}
         /// ensuring <see cref=""ApiException.ResponseBody""/> is populated.
         /// </summary>
         public bool ReadResponseAsString {{ get; set; }}
+
+        /// <summary>
+        /// Client-wide request defaults such as headers, query parameters, retries, and timeout.
+        /// </summary>
+        public global::{client.Settings.Namespace}.AutoSDKClientOptions Options {{ get; }}
 
         {string.Empty.ToXmlDocumentationSummary(level: 8)}
 {(hasOptions

--- a/src/libs/AutoSDK.CSharp/Sources/Sources.Methods.cs
+++ b/src/libs/AutoSDK.CSharp/Sources/Sources.Methods.cs
@@ -263,6 +263,31 @@ namespace {endPoint.Settings.Namespace}
         return $"{endPoint.NotAsyncMethodName}AsResponseAsync";
     }
 
+    private static string GetSendExpression(
+        EndPoint endPoint,
+        string requestVariableName,
+        string cancellationTokenVariableName)
+    {
+        var hasOAuth2Authorization = endPoint.Authorizations.Any(static x => x.Type is SecuritySchemeType.OAuth2);
+        var rootClassName = endPoint.Settings.ClassName.Replace(".", string.Empty);
+        var completionOption = $"global::System.Net.Http.HttpCompletionOption.{(endPoint.Stream
+            ? nameof(HttpCompletionOption.ResponseHeadersRead)
+            : nameof(HttpCompletionOption.ResponseContentRead))}";
+
+        return hasOAuth2Authorization
+            ? $@"global::{endPoint.Settings.Namespace}.{rootClassName}.AutoSDKOAuth2Helpers.SendAsync(
+                httpClient: HttpClient,
+                request: {requestVariableName},
+                completionOption: {completionOption},
+                authorizations: __authorizations,
+                oAuth2Coordinator: AutoSDKOAuth2State,
+                cancellationToken: {cancellationTokenVariableName})"
+            : $@"HttpClient.SendAsync(
+                request: {requestVariableName},
+                completionOption: {completionOption},
+                cancellationToken: {cancellationTokenVariableName})";
+    }
+
     private static string GetSuccessResponseBodyType(EndPoint endPoint)
     {
         if (string.IsNullOrWhiteSpace(endPoint.SuccessResponse.Type.CSharpType))
@@ -291,29 +316,14 @@ namespace {endPoint.Settings.Namespace}
                 request: request,")}
 {endPoint.Parameters.Where(x => x is { Location: not null } && (!x.IsRequired || x.HasSchemaDefault)).Select(x => $@"
                 {x.ParameterName}: {x.ParameterName},").Inject()}
+                requestOptions: requestOptions,
                 cancellationToken: cancellationToken".RemoveBlankLinesWhereOnlyWhitespaces();
     }
 
     public static string GenerateMethod(
         EndPoint endPoint, bool isInterface = false, bool returnResponseWrapper = false)
     {
-        var hasOAuth2Authorization = endPoint.Authorizations.Any(static x => x.Type is SecuritySchemeType.OAuth2);
-        var rootClassName = endPoint.Settings.ClassName.Replace(".", string.Empty);
-        var completionOption = $"global::System.Net.Http.HttpCompletionOption.{(endPoint.Stream
-            ? nameof(HttpCompletionOption.ResponseHeadersRead)
-            : nameof(HttpCompletionOption.ResponseContentRead))}";
-        var sendExpression = hasOAuth2Authorization
-            ? $@"global::{endPoint.Settings.Namespace}.{rootClassName}.AutoSDKOAuth2Helpers.SendAsync(
-                httpClient: HttpClient,
-                request: __httpRequest,
-                completionOption: {completionOption},
-                authorizations: __authorizations,
-                oAuth2Coordinator: AutoSDKOAuth2State,
-                cancellationToken: cancellationToken)"
-            : $@"HttpClient.SendAsync(
-                request: __httpRequest,
-                completionOption: {completionOption},
-                cancellationToken: cancellationToken)";
+        var sendExpression = GetSendExpression(endPoint, "__httpRequest", "__effectiveCancellationToken");
         var taskType = returnResponseWrapper
             ? $"global::System.Threading.Tasks.Task<{GetResponseWrapperType(endPoint)}>"
             : endPoint.RawStream
@@ -335,7 +345,7 @@ namespace {endPoint.Settings.Namespace}
             ? ";"
             : !returnResponseWrapper && ShouldGenerateResponseWrapperMethod(endPoint)
             ? string.IsNullOrWhiteSpace(endPoint.SuccessResponse.Type.CSharpType)
-                ? @$"
+            ? @$"
         {{
             await {GetResponseWrapperMethodName(endPoint)}(
 {GenerateMethodInvocationArguments(endPoint)}
@@ -381,83 +391,161 @@ namespace {endPoint.Settings.Namespace}
                 {x.Type.CSharpTypeWithoutNullability}.{y.Property} => ""{y.Value}"",").Inject()}
                 _ => throw new global::System.NotImplementedException(""Enum value not implemented.""),
             }};").Inject() : TrimmedLine)}
-{GeneratePathAndQuery(endPoint, authorizationVariableName: endPoint.AuthorizationRequirements.IsEmpty ? "Authorizations" : "__authorizations")}
-            using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
-                method: {GetHttpMethod(endPoint.HttpMethod)},
-                requestUri: new global::System.Uri(__path, global::System.UriKind.RelativeOrAbsolute));
+            using var __timeoutCancellationTokenSource = global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.CreateTimeoutCancellationTokenSource(
+                clientOptions: Options,
+                requestOptions: requestOptions,
+                cancellationToken: cancellationToken);
+            var __effectiveCancellationToken = __timeoutCancellationTokenSource?.Token ?? cancellationToken;
+            var __effectiveReadResponseAsString = global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.GetReadResponseAsString(
+                clientOptions: Options,
+                requestOptions: requestOptions,
+                fallbackValue: ReadResponseAsString);
+            var __maxAttempts = global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.GetMaxAttempts(
+                clientOptions: Options,
+                requestOptions: requestOptions,
+                supportsRetry: true);
+
+            global::System.Net.Http.HttpRequestMessage __CreateHttpRequest()
+            {{
+{GeneratePathAndQuery(endPoint, authorizationVariableName: endPoint.AuthorizationRequirements.IsEmpty ? "Authorizations" : "__authorizations").AddIndent(4)}
+                __path = global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.AppendQueryParameters(
+                    path: __path,
+                    clientParameters: Options.QueryParameters,
+                    requestParameters: requestOptions?.QueryParameters);
+                var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
+                    method: {GetHttpMethod(endPoint.HttpMethod)},
+                    requestUri: new global::System.Uri(__path, global::System.UriKind.RelativeOrAbsolute));
 #if NET6_0_OR_GREATER
 {           // Use HTTP/3.0 or HTTP/2.0 if available
             // https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-http3#httpclient-settings
     TrimmedLine}
-            __httpRequest.Version = global::System.Net.HttpVersion.Version11;
-            __httpRequest.VersionPolicy = global::System.Net.Http.HttpVersionPolicy.RequestVersionOrHigher;
+                __httpRequest.Version = global::System.Net.HttpVersion.Version11;
+                __httpRequest.VersionPolicy = global::System.Net.Http.HttpVersionPolicy.RequestVersionOrHigher;
 #endif
 {(endPoint.Authorizations.Any(x => x is
     { Type: SecuritySchemeType.ApiKey, In: ParameterLocation.Header } or
     { Type: SecuritySchemeType.Http } or
     { Type: SecuritySchemeType.OAuth2 }) ? @$"
-            foreach (var __authorization in {(endPoint.AuthorizationRequirements.IsEmpty ? "Authorizations" : "__authorizations")})
-            {{
-                if (__authorization.Type == ""{SecuritySchemeType.Http:G}"" ||
-                    __authorization.Type == ""{SecuritySchemeType.OAuth2:G}"")
+                foreach (var __authorization in {(endPoint.AuthorizationRequirements.IsEmpty ? "Authorizations" : "__authorizations")})
                 {{
-                    __httpRequest.Headers.Authorization = new global::System.Net.Http.Headers.AuthenticationHeaderValue(
-                        scheme: __authorization.Name,
-                        parameter: __authorization.Value);
-                }}
-                else if (__authorization.Type == ""{SecuritySchemeType.ApiKey:G}"" &&
-                         __authorization.Location == ""{ParameterLocation.Header:G}"")
-                {{
-                    __httpRequest.Headers.Add(__authorization.Name, __authorization.Value);
-                }}
-            }}" : TrimmedLine)}
+                    if (__authorization.Type == ""{SecuritySchemeType.Http:G}"" ||
+                        __authorization.Type == ""{SecuritySchemeType.OAuth2:G}"")
+                    {{
+                        __httpRequest.Headers.Authorization = new global::System.Net.Http.Headers.AuthenticationHeaderValue(
+                            scheme: __authorization.Name,
+                            parameter: __authorization.Value);
+                    }}
+                    else if (__authorization.Type == ""{SecuritySchemeType.ApiKey:G}"" &&
+                             __authorization.Location == ""{ParameterLocation.Header:G}"")
+                    {{
+                        __httpRequest.Headers.Add(__authorization.Name, __authorization.Value);
+                    }}
+                }}" : TrimmedLine)}
 {(endPoint.Parameters.Any(x => x is { Location: ParameterLocation.Header }) ? "" : TrimmedLine)}
 {endPoint.Parameters
     .Where(x => x is { Location: ParameterLocation.Header, IsRequired: true })
     .Select(x => $@"
-            __httpRequest.Headers.TryAddWithoutValidation(""{x.Id}"", {x.ParameterName}{(x.Type.IsEnum && !x.Type.IsAnyOfLike ? ".ToValueString()" : ".ToString()")});").Inject()}
+                __httpRequest.Headers.TryAddWithoutValidation(""{x.Id}"", {x.ParameterName}{(x.Type.IsEnum && !x.Type.IsAnyOfLike ? ".ToValueString()" : ".ToString()")});").Inject()}
 {endPoint.Parameters
     .Where(x => x is { Location: ParameterLocation.Header, IsRequired: false })
     .Select(x => $@"
-            if ({x.ParameterName} != default)
-            {{
-                __httpRequest.Headers.TryAddWithoutValidation(""{x.Id}"", {x.ParameterName}{(x.Type.IsEnum && !x.Type.IsAnyOfLike ? "?.ToValueString() ?? string.Empty" : ".ToString()")});
-            }}").Inject()}
+                if ({x.ParameterName} != default)
+                {{
+                    __httpRequest.Headers.TryAddWithoutValidation(""{x.Id}"", {x.ParameterName}{(x.Type.IsEnum && !x.Type.IsAnyOfLike ? "?.ToValueString() ?? string.Empty" : ".ToString()")});
+                }}").Inject()}
 {(endPoint.Parameters.Any(x => x is { Location: ParameterLocation.Header }) ? "" : TrimmedLine)}
-{GenerateCookieParameterHandling(endPoint)}
+{GenerateCookieParameterHandling(endPoint).AddIndent(4)}
  
-{GenerateRequestData(endPoint)}
+{GenerateRequestData(endPoint).AddIndent(4)}
+                global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.ApplyHeaders(
+                    request: __httpRequest,
+                    clientHeaders: Options.Headers,
+                    requestHeaders: requestOptions?.Headers);
 
-            PrepareRequest(
-                client: HttpClient,
-                request: __httpRequest);
-            Prepare{endPoint.NotAsyncMethodName}Request(
-                httpClient: HttpClient,
-                httpRequestMessage: __httpRequest{endPoint.Parameters
+                PrepareRequest(
+                    client: HttpClient,
+                    request: __httpRequest);
+                Prepare{endPoint.NotAsyncMethodName}Request(
+                    httpClient: HttpClient,
+                    httpRequestMessage: __httpRequest{endPoint.Parameters
                     .Where(x => x.Location != null)
                     .Select(x => $@",
-                {x.ParameterName}: {x.ParameterName}").Inject(emptyValue: "")}{(string.IsNullOrWhiteSpace(endPoint.RequestType.CSharpType) ? "" : @",
-                request: request")});
+                    {x.ParameterName}: {x.ParameterName}").Inject(emptyValue: "")}{(string.IsNullOrWhiteSpace(endPoint.RequestType.CSharpType) ? "" : @",
+                    request: request")});
 
-            {(endPoint.RawStream ? "" : "using ")}var __response = await {sendExpression}.ConfigureAwait(false);
-{(endPoint.RawStream ? @"
+                return __httpRequest;
+            }}
+
+            global::System.Net.Http.HttpRequestMessage? __httpRequest = null;
+            global::System.Net.Http.HttpResponseMessage? __response = null;
             try
-            {" : TrimmedLine)}
+            {{
+                for (var __attempt = 1; __attempt <= __maxAttempts; __attempt++)
+                {{
+                    __httpRequest = __CreateHttpRequest();
+                    try
+                    {{
+                        __response = await {sendExpression}.ConfigureAwait(false);
+                    }}
+                    catch (global::System.Net.Http.HttpRequestException) when (__attempt < __maxAttempts && !__effectiveCancellationToken.IsCancellationRequested)
+                    {{
+                        __httpRequest.Dispose();
+                        __httpRequest = null;
+                        await global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.DelayBeforeRetryAsync(
+                            clientOptions: Options,
+                            requestOptions: requestOptions,
+                            cancellationToken: __effectiveCancellationToken).ConfigureAwait(false);
+                        continue;
+                    }}
 
-            ProcessResponse(
-                client: HttpClient,
-                response: __response);
-            Process{endPoint.NotAsyncMethodName}Response(
-                httpClient: HttpClient,
-                httpResponseMessage: __response);
-{GenerateResponse(endPoint, wrapSuccessResponse: returnResponseWrapper)}
+                    if (__response != null &&
+                        __attempt < __maxAttempts &&
+                        global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.ShouldRetryStatusCode(__response.StatusCode))
+                    {{
+                        __response.Dispose();
+                        __response = null;
+                        __httpRequest.Dispose();
+                        __httpRequest = null;
+                        await global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.DelayBeforeRetryAsync(
+                            clientOptions: Options,
+                            requestOptions: requestOptions,
+                            cancellationToken: __effectiveCancellationToken).ConfigureAwait(false);
+                        continue;
+                    }}
+
+                    break;
+                }}
+
+                if (__response == null)
+                {{
+                    throw new global::System.InvalidOperationException(""No response received."");
+                }}
 {(endPoint.RawStream ? @"
-            }
-            catch
-            {
-                __response.Dispose();
-                throw;
-            }" : TrimmedLine)}
+                try
+                {" : @"
+                using (__response)
+                {")}
+
+                ProcessResponse(
+                    client: HttpClient,
+                    response: __response);
+                Process{endPoint.NotAsyncMethodName}Response(
+                    httpClient: HttpClient,
+                    httpResponseMessage: __response);
+{GenerateResponse(endPoint, wrapSuccessResponse: returnResponseWrapper, cancellationTokenVariableName: "__effectiveCancellationToken", readResponseAsStringExpression: "__effectiveReadResponseAsString").AddIndent(4)}
+{(endPoint.RawStream ? @"
+                }
+                catch
+                {
+                    __response.Dispose();
+                    throw;
+                }" : @"
+                }")}
+            }}
+            finally
+            {{
+                __httpRequest?.Dispose();
+            }}
         }}";
 
         return $@" 
@@ -466,6 +554,7 @@ namespace {endPoint.Settings.Namespace}
         {x.Summary.ToXmlDocumentationForParam(x.ParameterName, level: 8)}").Inject()}
 {(string.IsNullOrWhiteSpace(endPoint.RequestType.CSharpType) ? TrimmedLine : @" 
         /// <param name=""request""></param>")}
+        /// <param name=""requestOptions"">Per-request overrides such as headers, query parameters, timeout, retries, and response buffering.</param>
         /// <param name=""cancellationToken"">The token to cancel the operation with</param>
         /// <exception cref=""global::{endPoint.Settings.Namespace}.ApiException""></exception>{(string.IsNullOrWhiteSpace(endPoint.Remarks) ? "" : $@"
         {endPoint.Remarks.ToXmlDocumentationRemarks(level: 8)}")}
@@ -477,6 +566,7 @@ namespace {endPoint.Settings.Namespace}
             {endPoint.RequestType.CSharpTypeWithoutNullability} request,")}
 {endPoint.Parameters.Where(x => x is { Location: not null } && (!x.IsRequired || x.HasSchemaDefault)).Select(x => $@"
             {x.Type.CSharpType} {x.ParameterName} = {x.ParameterDefaultValue},").Inject()}
+            global::{endPoint.Settings.Namespace}.AutoSDKRequestOptions? requestOptions = default,
             {cancellationTokenAttribute}global::System.Threading.CancellationToken cancellationToken = default){body}
  ".RemoveBlankLinesWhereOnlyWhitespaces();
     }
@@ -1033,21 +1123,23 @@ namespace {endPoint.Settings.Namespace}
     }
 
     private static string GenerateSystemNetHttpJsonReadCall(
-        EndPoint endPoint)
+        EndPoint endPoint,
+        string cancellationTokenVariableName)
     {
         var type = endPoint.SuccessResponse.Type.CSharpTypeWithNullabilityForValueTypes;
 
         if (endPoint.Settings.HasJsonSerializerContext())
         {
-            return $"await global::{endPoint.Settings.Namespace}.AutoSdkPolyfills.ReadFromJsonAsync<{type}>(__response.Content, JsonSerializerContext, cancellationToken).ConfigureAwait(false)";
+            return $"await global::{endPoint.Settings.Namespace}.AutoSdkPolyfills.ReadFromJsonAsync<{type}>(__response.Content, JsonSerializerContext, {cancellationTokenVariableName}).ConfigureAwait(false)";
         }
 
-        return $"await global::{endPoint.Settings.Namespace}.AutoSdkPolyfills.ReadFromJsonAsync<{type}>(__response.Content, JsonSerializerOptions, cancellationToken).ConfigureAwait(false)";
+        return $"await global::{endPoint.Settings.Namespace}.AutoSdkPolyfills.ReadFromJsonAsync<{type}>(__response.Content, JsonSerializerOptions, {cancellationTokenVariableName}).ConfigureAwait(false)";
     }
 
     private static string GenerateUnbufferedSuccessResponseHandling(
         EndPoint endPoint,
-        bool wrapSuccessResponse)
+        bool wrapSuccessResponse,
+        string cancellationTokenVariableName)
     {
         var jsonSerializer = endPoint.Settings.JsonSerializerType.GetSerializer();
 
@@ -1065,7 +1157,7 @@ namespace {endPoint.Settings.Namespace}
         {
             if (ShouldUseSystemNetHttpJsonForSuccessResponse(endPoint))
             {
-                var readCall = GenerateSystemNetHttpJsonReadCall(endPoint);
+                var readCall = GenerateSystemNetHttpJsonReadCall(endPoint, cancellationTokenVariableName);
 
                 return wrapSuccessResponse
                     ? $@" 
@@ -1082,7 +1174,7 @@ namespace {endPoint.Settings.Namespace}
                 ? $@" 
                     using var __content = await __response.Content.ReadAsStreamAsync(
 #if NET5_0_OR_GREATER
-                        cancellationToken
+                        {cancellationTokenVariableName}
 #endif
                     ).ConfigureAwait(false);
 
@@ -1092,7 +1184,7 @@ namespace {endPoint.Settings.Namespace}
                 : $@" 
                     using var __content = await __response.Content.ReadAsStreamAsync(
 #if NET5_0_OR_GREATER
-                        cancellationToken
+                        {cancellationTokenVariableName}
 #endif
                     ).ConfigureAwait(false);
 
@@ -1113,7 +1205,7 @@ namespace {endPoint.Settings.Namespace}
             _ => "ByteArray",
         }}Async(
 #if NET5_0_OR_GREATER
-                        cancellationToken
+                        {cancellationTokenVariableName}
 #endif
                     ).ConfigureAwait(false);
 
@@ -1122,7 +1214,9 @@ namespace {endPoint.Settings.Namespace}
 
     public static string GenerateResponse(
         EndPoint endPoint,
-        bool wrapSuccessResponse = false)
+        bool wrapSuccessResponse = false,
+        string cancellationTokenVariableName = "cancellationToken",
+        string readResponseAsStringExpression = "ReadResponseAsString")
     {
         var jsonSerializer = endPoint.Settings.JsonSerializerType.GetSerializer();
 
@@ -1140,7 +1234,7 @@ namespace {endPoint.Settings.Namespace}
                 {{
                     __content = await __response.Content.ReadAsStringAsync(
 #if NET5_0_OR_GREATER
-                        cancellationToken
+                        {cancellationTokenVariableName}
 #endif
                     ).ConfigureAwait(false);
                 }}
@@ -1163,12 +1257,12 @@ namespace {endPoint.Settings.Namespace}
 
             using var __stream = await __response.Content.ReadAsStreamAsync(
 #if NET5_0_OR_GREATER
-                cancellationToken
+                {cancellationTokenVariableName}
 #endif
             ).ConfigureAwait(false);
 
             await foreach (var __sseEvent in global::System.Net.ServerSentEvents.SseParser
-                .Create(__stream).EnumerateAsync(cancellationToken))
+                .Create(__stream).EnumerateAsync({cancellationTokenVariableName}))
             {{
                 var __content = __sseEvent.Data;
 {(!string.IsNullOrEmpty(endPoint.StreamTerminator)
@@ -1204,7 +1298,7 @@ namespace {endPoint.Settings.Namespace}
             var __contentBuilder = new global::System.Text.StringBuilder();
             var __characterBuffer = new char[1];
 
-            while (!cancellationToken.IsCancellationRequested)
+            while (!{cancellationTokenVariableName}.IsCancellationRequested)
             {{
                 var __read = await __reader.ReadAsync(__characterBuffer, 0, 1).ConfigureAwait(false);
                 if (__read == 0)
@@ -1268,7 +1362,7 @@ namespace {endPoint.Settings.Namespace}
                 : $@"
             using var __reader = new global::System.IO.StreamReader(__stream);
 
-            while (!__reader.EndOfStream && !cancellationToken.IsCancellationRequested)
+            while (!__reader.EndOfStream && !{cancellationTokenVariableName}.IsCancellationRequested)
             {{
                 var __content = await __reader.ReadLineAsync().ConfigureAwait(false) ?? string.Empty;
                 if (global::System.String.IsNullOrWhiteSpace(__content))
@@ -1303,7 +1397,7 @@ namespace {endPoint.Settings.Namespace}
                 {{
                     __content = await __response.Content.ReadAsStringAsync(
 #if NET5_0_OR_GREATER
-                        cancellationToken
+                        {cancellationTokenVariableName}
 #endif
                     ).ConfigureAwait(false);
                 }}
@@ -1326,7 +1420,7 @@ namespace {endPoint.Settings.Namespace}
 
             using var __stream = await __response.Content.ReadAsStreamAsync(
 #if NET5_0_OR_GREATER
-                cancellationToken
+                {cancellationTokenVariableName}
 #endif
             ).ConfigureAwait(false);
 {streamReadLoop}
@@ -1355,15 +1449,15 @@ namespace {endPoint.Settings.Namespace}
                 {x.Type.CSharpTypeWithoutNullability}? __value_{x.StatusCode} = null;" : TrimmedLine)}
                 try
                 {{
-                    if (ReadResponseAsString)
+                    if ({readResponseAsStringExpression})
                     {{
-                        __content_{x.StatusCode} = await __response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                        __content_{x.StatusCode} = await __response.Content.ReadAsStringAsync({cancellationTokenVariableName}).ConfigureAwait(false);
 {(!string.IsNullOrWhiteSpace(x.Type.CSharpTypeWithoutNullability) ? $@" 
                         __value_{x.StatusCode} = {jsonSerializer.GenerateDeserializeCall($"__content_{x.StatusCode}", x.Type, endPoint.Settings.JsonSerializerContext)};" : TrimmedLine)}
                     }}
                     else
                     {{
-                        __content_{x.StatusCode} = await __response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                        __content_{x.StatusCode} = await __response.Content.ReadAsStringAsync({cancellationTokenVariableName}).ConfigureAwait(false);
 {(!string.IsNullOrWhiteSpace(x.Type.CSharpTypeWithoutNullability) ? $@"
                         __value_{x.StatusCode} = {jsonSerializer.GenerateDeserializeCall($"__content_{x.StatusCode}", x.Type, endPoint.Settings.JsonSerializerContext)};" : TrimmedLine)}
                     }}
@@ -1400,7 +1494,7 @@ namespace {endPoint.Settings.Namespace}
 
                 var __content = await __response.Content.ReadAsStreamAsync(
 #if NET5_0_OR_GREATER
-                    cancellationToken
+                    {cancellationTokenVariableName}
 #endif
                 ).ConfigureAwait(false);
 
@@ -1418,7 +1512,7 @@ namespace {endPoint.Settings.Namespace}
                 {{
                     __content = await __response.Content.ReadAsStringAsync(
 #if NET5_0_OR_GREATER
-                        cancellationToken
+                        {cancellationTokenVariableName}
 #endif
                     ).ConfigureAwait(false);
                 }}
@@ -1443,7 +1537,7 @@ namespace {endPoint.Settings.Namespace}
 
         return @$"{errors}
 
-            if (ReadResponseAsString)
+            if ({readResponseAsStringExpression})
             {{
                 var __content = await __response.Content.ReadAs{endPoint.ContentType switch
         {
@@ -1452,7 +1546,7 @@ namespace {endPoint.Settings.Namespace}
             _ => "ByteArray",
         }}Async(
 #if NET5_0_OR_GREATER
-                    cancellationToken
+                    {cancellationTokenVariableName}
 #endif
                 ).ConfigureAwait(false);
 
@@ -1505,7 +1599,7 @@ namespace {endPoint.Settings.Namespace}
                 try
                 {{
                     __response.EnsureSuccessStatusCode();
-{GenerateUnbufferedSuccessResponseHandling(endPoint, wrapSuccessResponse)}
+{GenerateUnbufferedSuccessResponseHandling(endPoint, wrapSuccessResponse, cancellationTokenVariableName)}
                 }}
                 catch (global::System.Exception __ex)
                 {{
@@ -1514,7 +1608,7 @@ namespace {endPoint.Settings.Namespace}
                     {{
                         __content = await __response.Content.ReadAsStringAsync(
 #if NET5_0_OR_GREATER
-                            cancellationToken
+                            {cancellationTokenVariableName}
 #endif
                         ).ConfigureAwait(false);
                     }}
@@ -1550,7 +1644,7 @@ namespace {endPoint.Settings.Namespace}
         if (endPoint.IsMultipartFormData)
         {
             return $@" 
-            using var __httpRequestContent = new global::System.Net.Http.MultipartFormDataContent();
+            var __httpRequestContent = new global::System.Net.Http.MultipartFormDataContent();
 {endPoint.Parameters.Where(x => !x.IsMultiPartFormDataFilename).Select(x =>
 {
     var isBinaryArray = x.Type.IsArray && !x.Type.SubTypes.IsEmpty && x.Type.SubTypes[0].Unbox<TypeData>().IsBinary;
@@ -1758,6 +1852,7 @@ namespace {endPoint.Settings.Namespace}
 {endPoint.Parameters.Where(x => x.Location != null).Select(x => $@"
                 {x.ParameterName}: {x.ParameterName},").Inject()}
                 request: __request,
+                requestOptions: requestOptions,
                 cancellationToken: cancellationToken){configureAwaitResponse};
 {(endPoint.EnumerableStream ? @"
             
@@ -1773,6 +1868,7 @@ namespace {endPoint.Settings.Namespace}
         {endPoint.Summary.ToXmlDocumentationSummary(level: 8)}
 {parameters.Select(x => $@"
         {x.Summary.ToXmlDocumentationForParam(x.ParameterName, level: 8)}").Inject()}
+        /// <param name=""requestOptions"">Per-request overrides such as headers, query parameters, timeout, retries, and response buffering.</param>
         /// <param name=""cancellationToken"">The token to cancel the operation with</param>
         /// <exception cref=""global::System.InvalidOperationException""></exception>
         {GenerateEndPointAttributes(endPoint)}
@@ -1785,6 +1881,7 @@ namespace {endPoint.Settings.Namespace}
 {x.DisableDeprecationWarningIfRequired}
             {x.Type.CSharpType} {x.ParameterName} = {x.ParameterDefaultValue},
 {x.DisableDeprecationWarningIfRequired}".TrimEnd()).Inject()}
+            global::{endPoint.Settings.Namespace}.AutoSDKRequestOptions? requestOptions = default,
             {cancellationTokenAttribute}global::System.Threading.CancellationToken cancellationToken = default){body}
  ".RemoveBlankLinesWhereOnlyWhitespaces();
     }

--- a/src/libs/AutoSDK.CSharp/Sources/Sources.OptionsSupport.cs
+++ b/src/libs/AutoSDK.CSharp/Sources/Sources.OptionsSupport.cs
@@ -1,0 +1,248 @@
+using AutoSDK.Extensions;
+using AutoSDK.Models;
+
+namespace AutoSDK.Generation;
+
+public static partial class Sources
+{
+    public static string GenerateOptionsSupport(
+        CSharpSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        return $@"
+#nullable enable
+
+namespace {settings.Namespace}
+{{
+    /// <summary>
+    /// Global defaults applied to generated SDK requests.
+    /// </summary>
+    public sealed class AutoSDKClientOptions
+    {{
+        /// <summary>
+        /// Additional headers applied to every request after generated headers are set.
+        /// Entries with the same key overwrite earlier header values.
+        /// </summary>
+        public global::System.Collections.Generic.Dictionary<string, string> Headers {{ get; }} =
+            new global::System.Collections.Generic.Dictionary<string, string>(global::System.StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Additional query parameters appended to every request.
+        /// Request-level entries with the same key are appended after client defaults.
+        /// </summary>
+        public global::System.Collections.Generic.Dictionary<string, string> QueryParameters {{ get; }} =
+            new global::System.Collections.Generic.Dictionary<string, string>(global::System.StringComparer.Ordinal);
+
+        /// <summary>
+        /// Optional timeout applied to the full request execution.
+        /// </summary>
+        public global::System.TimeSpan? Timeout {{ get; set; }}
+
+        /// <summary>
+        /// Default retry behavior for generated HTTP requests.
+        /// </summary>
+        public global::{settings.Namespace}.AutoSDKRetryOptions Retry {{ get; set; }} = new global::{settings.Namespace}.AutoSDKRetryOptions();
+
+        /// <summary>
+        /// Overrides the client-wide response buffering mode when set.
+        /// </summary>
+        public bool? ReadResponseAsString {{ get; set; }}
+    }}
+
+    /// <summary>
+    /// Per-request overrides applied on top of <see cref=""AutoSDKClientOptions""/>.
+    /// </summary>
+    public sealed class AutoSDKRequestOptions
+    {{
+        /// <summary>
+        /// Additional headers applied after generated and client-level headers.
+        /// </summary>
+        public global::System.Collections.Generic.Dictionary<string, string> Headers {{ get; }} =
+            new global::System.Collections.Generic.Dictionary<string, string>(global::System.StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Additional query parameters appended after generated and client-level query parameters.
+        /// </summary>
+        public global::System.Collections.Generic.Dictionary<string, string> QueryParameters {{ get; }} =
+            new global::System.Collections.Generic.Dictionary<string, string>(global::System.StringComparer.Ordinal);
+
+        /// <summary>
+        /// Optional timeout override for this request.
+        /// </summary>
+        public global::System.TimeSpan? Timeout {{ get; set; }}
+
+        /// <summary>
+        /// Optional retry override for this request.
+        /// </summary>
+        public global::{settings.Namespace}.AutoSDKRetryOptions? Retry {{ get; set; }}
+
+        /// <summary>
+        /// Overrides response buffering for this request when set.
+        /// </summary>
+        public bool? ReadResponseAsString {{ get; set; }}
+    }}
+
+    /// <summary>
+    /// Retry settings for generated HTTP requests.
+    /// </summary>
+    public sealed class AutoSDKRetryOptions
+    {{
+        /// <summary>
+        /// Total number of attempts, including the initial request.
+        /// Values less than 1 are normalized to 1.
+        /// </summary>
+        public int MaxAttempts {{ get; set; }} = 1;
+
+        /// <summary>
+        /// Optional fixed delay between retry attempts.
+        /// </summary>
+        public global::System.TimeSpan? Delay {{ get; set; }}
+    }}
+
+    internal static class AutoSDKRequestOptionsSupport
+    {{
+        internal static bool GetReadResponseAsString(
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::{settings.Namespace}.AutoSDKRequestOptions? requestOptions,
+            bool fallbackValue)
+        {{
+            return requestOptions?.ReadResponseAsString ??
+                   clientOptions.ReadResponseAsString ??
+                   fallbackValue;
+        }}
+
+        internal static global::System.Threading.CancellationTokenSource? CreateTimeoutCancellationTokenSource(
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::{settings.Namespace}.AutoSDKRequestOptions? requestOptions,
+            global::System.Threading.CancellationToken cancellationToken)
+        {{
+            var timeout = requestOptions?.Timeout ?? clientOptions.Timeout;
+            if (!timeout.HasValue || timeout.Value <= global::System.TimeSpan.Zero)
+            {{
+                return null;
+            }}
+
+            var cancellationTokenSource = global::System.Threading.CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancellationTokenSource.CancelAfter(timeout.Value);
+            return cancellationTokenSource;
+        }}
+
+        internal static int GetMaxAttempts(
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::{settings.Namespace}.AutoSDKRequestOptions? requestOptions,
+            bool supportsRetry)
+        {{
+            if (!supportsRetry)
+            {{
+                return 1;
+            }}
+
+            var maxAttempts = requestOptions?.Retry?.MaxAttempts ??
+                              clientOptions.Retry?.MaxAttempts ??
+                              1;
+            return maxAttempts < 1 ? 1 : maxAttempts;
+        }}
+
+        internal static async global::System.Threading.Tasks.Task DelayBeforeRetryAsync(
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::{settings.Namespace}.AutoSDKRequestOptions? requestOptions,
+            global::System.Threading.CancellationToken cancellationToken)
+        {{
+            var delay = requestOptions?.Retry?.Delay ??
+                        clientOptions.Retry?.Delay;
+            if (!delay.HasValue || delay.Value <= global::System.TimeSpan.Zero)
+            {{
+                return;
+            }}
+
+            await global::System.Threading.Tasks.Task.Delay(delay.Value, cancellationToken).ConfigureAwait(false);
+        }}
+
+        internal static bool ShouldRetryStatusCode(
+            global::System.Net.HttpStatusCode statusCode)
+        {{
+            return (int)statusCode switch
+            {{
+                408 => true,
+                429 => true,
+                500 => true,
+                502 => true,
+                503 => true,
+                504 => true,
+                _ => false,
+            }};
+        }}
+
+        internal static string AppendQueryParameters(
+            string path,
+            global::System.Collections.Generic.Dictionary<string, string> clientParameters,
+            global::System.Collections.Generic.Dictionary<string, string>? requestParameters)
+        {{
+            var hasClientParameters = clientParameters != null && clientParameters.Count > 0;
+            var hasRequestParameters = requestParameters != null && requestParameters.Count > 0;
+            if (!hasClientParameters && !hasRequestParameters)
+            {{
+                return path;
+            }}
+
+            var builder = new global::System.Text.StringBuilder(path ?? string.Empty);
+            var hasQuery = builder.ToString().Contains(""?"", global::System.StringComparison.Ordinal);
+            AppendParameters(builder, clientParameters, ref hasQuery);
+            AppendParameters(builder, requestParameters, ref hasQuery);
+            return builder.ToString();
+        }}
+
+        internal static void ApplyHeaders(
+            global::System.Net.Http.HttpRequestMessage request,
+            global::System.Collections.Generic.Dictionary<string, string> clientHeaders,
+            global::System.Collections.Generic.Dictionary<string, string>? requestHeaders)
+        {{
+            ApplyHeadersCore(request, clientHeaders);
+            ApplyHeadersCore(request, requestHeaders);
+        }}
+
+        private static void AppendParameters(
+            global::System.Text.StringBuilder builder,
+            global::System.Collections.Generic.Dictionary<string, string>? parameters,
+            ref bool hasQuery)
+        {{
+            if (parameters == null || parameters.Count == 0)
+            {{
+                return;
+            }}
+
+            foreach (var parameter in parameters)
+            {{
+                builder.Append(hasQuery ? '&' : '?');
+                builder.Append(global::System.Uri.EscapeDataString(parameter.Key));
+                builder.Append('=');
+                builder.Append(global::System.Uri.EscapeDataString(parameter.Value ?? string.Empty));
+                hasQuery = true;
+            }}
+        }}
+
+        private static void ApplyHeadersCore(
+            global::System.Net.Http.HttpRequestMessage request,
+            global::System.Collections.Generic.Dictionary<string, string>? headers)
+        {{
+            if (headers == null || headers.Count == 0)
+            {{
+                return;
+            }}
+
+            foreach (var header in headers)
+            {{
+                request.Headers.Remove(header.Key);
+                request.Content?.Headers.Remove(header.Key);
+
+                if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value ?? string.Empty) &&
+                    request.Content != null)
+                {{
+                    request.Content.Headers.TryAddWithoutValidation(header.Key, header.Value ?? string.Empty);
+                }}
+            }}
+        }}
+    }}
+}}".RemoveBlankLinesWhereOnlyWhitespaces();
+    }
+}

--- a/src/libs/AutoSDK.CSharp/Sources/Sources.cs
+++ b/src/libs/AutoSDK.CSharp/Sources/Sources.cs
@@ -407,6 +407,15 @@ public static partial class Sources
             Text: GeneratePathBuilder(settings, cancellationToken: cancellationToken));
     }
 
+    public static FileWithName OptionsSupport(
+        CSharpSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        return new FileWithName(
+            Name: $"{settings.Namespace}.OptionsSupport.g.cs",
+            Text: GenerateOptionsSupport(settings, cancellationToken: cancellationToken));
+    }
+
     public static FileWithName SecuritySupport(
         CSharpSettings settings,
         CancellationToken cancellationToken = default)

--- a/src/libs/AutoSDK.SourceGenerators/SdkGenerator.cs
+++ b/src/libs/AutoSDK.SourceGenerators/SdkGenerator.cs
@@ -51,6 +51,12 @@ public class SdkGenerator : IIncrementalGenerator
                 .AsFileWithName(), context, Id)
             .AddSource(context);
         supportData
+            .SelectAndReportExceptions((x, c) => ShouldGenerateOptionsSupport(x.Right)
+                ? Sources.OptionsSupport(x.Left, c)
+                : FileWithName.Empty
+                .AsFileWithName(), context, Id)
+            .AddSource(context);
+        supportData
             .SelectAndReportExceptions((x, c) => ShouldGenerateSecuritySupport(x.Right)
                 ? Sources.SecuritySupport(x.Left, c)
                 : FileWithName.Empty
@@ -217,6 +223,13 @@ public class SdkGenerator : IIncrementalGenerator
             !x.Methods.IsEmpty ||
             !x.Clients.IsEmpty ||
             !x.WebSocketClients.IsEmpty);
+    }
+
+    private static bool ShouldGenerateOptionsSupport(ImmutableArray<AutoSDK.Models.Data> data)
+    {
+        return data.Any(static x =>
+            !x.Methods.IsEmpty ||
+            !x.Clients.IsEmpty);
     }
 
     private static bool ShouldGenerateSecuritySupport(ImmutableArray<AutoSDK.Models.Data> data)

--- a/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
+++ b/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
@@ -260,6 +260,59 @@ public class CliTests
     }
 
     [TestMethod]
+    public async Task Generate_WithRequestAndClientOptions_EmitsOptionsSupportAndBuilds()
+    {
+        const string spec = """
+                            openapi: 3.0.3
+                            info:
+                              title: Options
+                              version: 1.0.0
+                            paths:
+                              /search:
+                                get:
+                                  operationId: search
+                                  parameters:
+                                    - in: query
+                                      name: q
+                                      schema:
+                                        type: string
+                                  responses:
+                                    '200':
+                                      description: OK
+                                      content:
+                                        application/json:
+                                          schema:
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: string
+                            """;
+
+        await GenerateFromContentAsync(
+            fileName: "request-options.yaml",
+            specContent: spec,
+            targetFramework: "net10.0",
+            namespaceValue: "Generated.Options",
+            assertGeneratedOutput: async outputDirectory =>
+            {
+                var generatedFiles = Directory.GetFiles(outputDirectory, "*.cs", SearchOption.AllDirectories);
+                generatedFiles.Should().NotBeEmpty();
+
+                var combinedSource = string.Join(
+                    Environment.NewLine,
+                    await Task.WhenAll(generatedFiles.Select(path => File.ReadAllTextAsync(path))));
+
+                combinedSource.Should().Contain("public sealed class AutoSDKClientOptions");
+                combinedSource.Should().Contain("public sealed class AutoSDKRequestOptions");
+                combinedSource.Should().Contain("global::Generated.Options.AutoSDKClientOptions? options = null");
+                combinedSource.Should().Contain("global::Generated.Options.AutoSDKRequestOptions? requestOptions = default");
+                combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.AppendQueryParameters(");
+                combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.ApplyHeaders(");
+                combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.GetMaxAttempts(");
+            });
+    }
+
+    [TestMethod]
     public async Task Generate_BufModuleInput_ScaffoldsGrpcClientProject()
     {
         var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/tests/AutoSDK.SnapshotTests/Tests.TwoProjectGeneration.cs
+++ b/src/tests/AutoSDK.SnapshotTests/Tests.TwoProjectGeneration.cs
@@ -128,6 +128,7 @@ public partial class Tests
         generatedSources.Should().Contain("G.Polyfills.g.cs");
         generatedSources.Should().Contain("G.Exceptions.g.cs");
         generatedSources.Should().Contain("G.PathBuilder.g.cs");
+        generatedSources.Should().Contain("G.OptionsSupport.g.cs");
         generatedSources.Should().Contain("G.JsonConverters.UnixTimestamp.g.cs");
     }
 }

--- a/src/tests/AutoSDK.UnitTests/RequestOptionsGenerationTests.cs
+++ b/src/tests/AutoSDK.UnitTests/RequestOptionsGenerationTests.cs
@@ -1,0 +1,101 @@
+using AutoSDK.Generation;
+using AutoSDK.Models;
+
+namespace AutoSDK.UnitTests;
+
+[TestClass]
+public class RequestOptionsGenerationTests
+{
+    private static CSharpSettings DefaultSettings => Settings.Default with
+    {
+        TargetFramework = "netstandard2.0",
+        Namespace = "G",
+        ClassName = "Api",
+        GenerateSdk = true,
+        GenerateConstructors = true,
+    };
+
+    [TestMethod]
+    public void GenerateClient_WithOptionsSupport_EmitsClientOptionsSurface()
+    {
+        const string yaml = """
+                            openapi: 3.0.3
+                            info:
+                              title: Options
+                              version: 1.0.0
+                            paths:
+                              /charges:
+                                post:
+                                  operationId: createCharge
+                                  responses:
+                                    '200':
+                                      description: OK
+                                      content:
+                                        application/json:
+                                          schema:
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: string
+                            """;
+
+        var settings = DefaultSettings;
+        var data = AutoSDK.Generation.Data.Prepare(((yaml, (CSharpSettings)settings), (CSharpSettings)settings));
+        var mainClient = data.Clients.Single(x => x.Id == "MainConstructor");
+        var clientSource = Sources.Client(mainClient).Text;
+        var supportSource = Sources.OptionsSupport(settings).Text;
+
+        clientSource.Should().Contain("public global::G.AutoSDKClientOptions Options { get; }");
+        clientSource.Should().Contain("global::G.AutoSDKClientOptions? options = null");
+        clientSource.Should().Contain("Options = options ?? new global::G.AutoSDKClientOptions();");
+        clientSource.Should().Contain("bool disposeHttpClient = true) : this(");
+        clientSource.Should().Contain("options: null,");
+
+        supportSource.Should().Contain("public sealed class AutoSDKClientOptions");
+        supportSource.Should().Contain("public sealed class AutoSDKRequestOptions");
+        supportSource.Should().Contain("public sealed class AutoSDKRetryOptions");
+    }
+
+    [TestMethod]
+    public void GenerateMethod_WithRequestOptions_EmitsPerRequestOverridesAndRetries()
+    {
+        const string yaml = """
+                            openapi: 3.0.3
+                            info:
+                              title: RequestOptions
+                              version: 1.0.0
+                            paths:
+                              /search:
+                                get:
+                                  operationId: search
+                                  parameters:
+                                    - in: query
+                                      name: q
+                                      schema:
+                                        type: string
+                                  responses:
+                                    '200':
+                                      description: OK
+                                      content:
+                                        application/json:
+                                          schema:
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: string
+                            """;
+
+        var settings = DefaultSettings;
+        var data = AutoSDK.Generation.Data.Prepare(((yaml, (CSharpSettings)settings), (CSharpSettings)settings));
+        var method = data.Methods.Single();
+        var methodSource = Sources.Method(method).Text;
+
+        methodSource.Should().Contain("global::G.AutoSDKRequestOptions? requestOptions = default");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.AppendQueryParameters(");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.ApplyHeaders(");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.CreateTimeoutCancellationTokenSource(");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.GetMaxAttempts(");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.ShouldRetryStatusCode(__response.StatusCode)");
+        methodSource.Should().Contain("if (__effectiveReadResponseAsString)");
+    }
+}


### PR DESCRIPTION
Closes #239

## Summary
- add generated client-wide and per-request options support for headers, query parameters, timeout, retries, and response buffering
- flow request options through generated client/method surfaces and keep constructor compatibility for existing generated callers
- wire options support into the source-generator path and add focused unit, CLI integration, and two-project snapshot coverage

## Validation
- dotnet build src/libs/AutoSDK.CSharp/AutoSDK.CSharp.csproj /p:TreatWarningsAsErrors=true
- dotnet build src/libs/AutoSDK.CLI/AutoSDK.CLI.csproj /p:TreatWarningsAsErrors=true
- dotnet test src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj --filter "FullyQualifiedName~RequestOptionsGenerationTests"
- dotnet test src/tests/AutoSDK.IntegrationTests.Cli/AutoSDK.IntegrationTests.Cli.csproj --filter "FullyQualifiedName~Generate_WithRequestAndClientOptions_EmitsOptionsSupportAndBuilds"
- dotnet test src/tests/AutoSDK.SnapshotTests/AutoSDK.SnapshotTests.csproj --filter "FullyQualifiedName~SdkGenerator_MethodsProject_EmitsRequiredSupportSources"