### PR TITLE
Add first-class request/response hooks or middleware for generated SDKs

### DIFF
--- a/src/libs/AutoSDK.CSharp/Sources/Sources.Methods.cs
+++ b/src/libs/AutoSDK.CSharp/Sources/Sources.Methods.cs
@@ -288,6 +288,37 @@ namespace {endPoint.Settings.Namespace}
                 cancellationToken: {cancellationTokenVariableName})";
     }
 
+    private static string GenerateHookInvocation(
+        EndPoint endPoint,
+        string methodName,
+        string helperMethodName,
+        string requestVariableName,
+        string responseExpression,
+        string exceptionExpression,
+        string attemptExpression,
+        string maxAttemptsExpression,
+        string willRetryExpression,
+        string cancellationTokenVariableName)
+    {
+        return $@"await global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.{helperMethodName}Async(
+                            clientOptions: Options,
+                            context: global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.CreateHookContext(
+                                operationId: {endPoint.Id.ToCSharpStringLiteral()},
+                                methodName: {methodName.ToCSharpStringLiteral()},
+                                pathTemplate: {endPoint.Path.ToCSharpStringLiteral()},
+                                httpMethod: {endPoint.HttpMethod.Method.ToCSharpStringLiteral()},
+                                baseUri: BaseUri,
+                                request: {requestVariableName}!,
+                                response: {responseExpression},
+                                exception: {exceptionExpression},
+                                clientOptions: Options,
+                                requestOptions: requestOptions,
+                                attempt: {attemptExpression},
+                                maxAttempts: {maxAttemptsExpression},
+                                willRetry: {willRetryExpression},
+                                cancellationToken: {cancellationTokenVariableName})).ConfigureAwait(false);";
+    }
+
     private static string GetSuccessResponseBodyType(EndPoint endPoint)
     {
         if (string.IsNullOrWhiteSpace(endPoint.SuccessResponse.Type.CSharpType))
@@ -341,6 +372,61 @@ namespace {endPoint.Settings.Namespace}
         var cancellationTokenAttribute = endPoint.EnumerableStream && !isInterface
             ? "[global::System.Runtime.CompilerServices.EnumeratorCancellation] "
             : string.Empty;
+        var beforeRequestHook = GenerateHookInvocation(
+            endPoint,
+            endPoint.MethodName,
+            helperMethodName: "OnBeforeRequest",
+            requestVariableName: "__httpRequest",
+            responseExpression: "null",
+            exceptionExpression: "null",
+            attemptExpression: "__attempt",
+            maxAttemptsExpression: "__maxAttempts",
+            willRetryExpression: "false",
+            cancellationTokenVariableName: "__effectiveCancellationToken");
+        var afterSuccessHook = GenerateHookInvocation(
+            endPoint,
+            endPoint.MethodName,
+            helperMethodName: "OnAfterSuccess",
+            requestVariableName: "__httpRequest",
+            responseExpression: "__response",
+            exceptionExpression: "null",
+            attemptExpression: "__attemptNumber",
+            maxAttemptsExpression: "__maxAttempts",
+            willRetryExpression: "false",
+            cancellationTokenVariableName: "__effectiveCancellationToken");
+        var afterRetryableStatusHook = GenerateHookInvocation(
+            endPoint,
+            endPoint.MethodName,
+            helperMethodName: "OnAfterError",
+            requestVariableName: "__httpRequest",
+            responseExpression: "__response",
+            exceptionExpression: "null",
+            attemptExpression: "__attempt",
+            maxAttemptsExpression: "__maxAttempts",
+            willRetryExpression: "true",
+            cancellationTokenVariableName: "__effectiveCancellationToken");
+        var afterErrorStatusHook = GenerateHookInvocation(
+            endPoint,
+            endPoint.MethodName,
+            helperMethodName: "OnAfterError",
+            requestVariableName: "__httpRequest",
+            responseExpression: "__response",
+            exceptionExpression: "null",
+            attemptExpression: "__attemptNumber",
+            maxAttemptsExpression: "__maxAttempts",
+            willRetryExpression: "false",
+            cancellationTokenVariableName: "__effectiveCancellationToken");
+        var afterExceptionHook = GenerateHookInvocation(
+            endPoint,
+            endPoint.MethodName,
+            helperMethodName: "OnAfterError",
+            requestVariableName: "__httpRequest",
+            responseExpression: "null",
+            exceptionExpression: "__exception",
+            attemptExpression: "__attempt",
+            maxAttemptsExpression: "__maxAttempts",
+            willRetryExpression: "__willRetry",
+            cancellationTokenVariableName: "__effectiveCancellationToken");
         var body = isInterface
             ? ";"
             : !returnResponseWrapper && ShouldGenerateResponseWrapperMethod(endPoint)
@@ -478,17 +564,27 @@ namespace {endPoint.Settings.Namespace}
 
             global::System.Net.Http.HttpRequestMessage? __httpRequest = null;
             global::System.Net.Http.HttpResponseMessage? __response = null;
+            var __attemptNumber = 0;
             try
             {{
                 for (var __attempt = 1; __attempt <= __maxAttempts; __attempt++)
                 {{
+                    __attemptNumber = __attempt;
                     __httpRequest = __CreateHttpRequest();
+                    {beforeRequestHook}
                     try
                     {{
                         __response = await {sendExpression}.ConfigureAwait(false);
                     }}
-                    catch (global::System.Net.Http.HttpRequestException) when (__attempt < __maxAttempts && !__effectiveCancellationToken.IsCancellationRequested)
+                    catch (global::System.Net.Http.HttpRequestException __exception)
                     {{
+                        var __willRetry = __attempt < __maxAttempts && !__effectiveCancellationToken.IsCancellationRequested;
+                        {afterExceptionHook}
+                        if (!__willRetry)
+                        {{
+                            throw;
+                        }}
+
                         __httpRequest.Dispose();
                         __httpRequest = null;
                         await global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.DelayBeforeRetryAsync(
@@ -502,6 +598,7 @@ namespace {endPoint.Settings.Namespace}
                         __attempt < __maxAttempts &&
                         global::{endPoint.Settings.Namespace}.AutoSDKRequestOptionsSupport.ShouldRetryStatusCode(__response.StatusCode))
                     {{
+                        {afterRetryableStatusHook}
                         __response.Dispose();
                         __response = null;
                         __httpRequest.Dispose();
@@ -532,6 +629,14 @@ namespace {endPoint.Settings.Namespace}
                 Process{endPoint.NotAsyncMethodName}Response(
                     httpClient: HttpClient,
                     httpResponseMessage: __response);
+                if (__response.IsSuccessStatusCode)
+                {{
+                    {afterSuccessHook}
+                }}
+                else
+                {{
+                    {afterErrorStatusHook}
+                }}
 {GenerateResponse(endPoint, wrapSuccessResponse: returnResponseWrapper, cancellationTokenVariableName: "__effectiveCancellationToken", readResponseAsStringExpression: "__effectiveReadResponseAsString").AddIndent(4)}
 {(endPoint.RawStream ? @"
                 }

--- a/src/libs/AutoSDK.CSharp/Sources/Sources.OptionsSupport.cs
+++ b/src/libs/AutoSDK.CSharp/Sources/Sources.OptionsSupport.cs
@@ -47,6 +47,24 @@ namespace {settings.Namespace}
         /// Overrides the client-wide response buffering mode when set.
         /// </summary>
         public bool? ReadResponseAsString {{ get; set; }}
+
+        /// <summary>
+        /// Reusable hooks invoked for every generated SDK request.
+        /// </summary>
+        public global::System.Collections.Generic.List<global::{settings.Namespace}.IAutoSDKHook> Hooks {{ get; }} =
+            new global::System.Collections.Generic.List<global::{settings.Namespace}.IAutoSDKHook>();
+
+        /// <summary>
+        /// Registers a hook for all requests issued by this client.
+        /// </summary>
+        /// <param name=""hook""></param>
+        /// <returns>The current options instance.</returns>
+        public global::{settings.Namespace}.AutoSDKClientOptions AddHook(
+            global::{settings.Namespace}.IAutoSDKHook hook)
+        {{
+            Hooks.Add(hook ?? throw new global::System.ArgumentNullException(nameof(hook)));
+            return this;
+        }}
     }}
 
     /// <summary>
@@ -99,8 +117,194 @@ namespace {settings.Namespace}
         public global::System.TimeSpan? Delay {{ get; set; }}
     }}
 
+    /// <summary>
+    /// Runtime hook interface for generated SDK lifecycle events.
+    /// </summary>
+    public interface IAutoSDKHook
+    {{
+        /// <summary>
+        /// Runs before a request is sent.
+        /// </summary>
+        /// <param name=""context""></param>
+        global::System.Threading.Tasks.Task OnBeforeRequestAsync(
+            global::{settings.Namespace}.AutoSDKHookContext context);
+
+        /// <summary>
+        /// Runs after a successful HTTP response is received.
+        /// </summary>
+        /// <param name=""context""></param>
+        global::System.Threading.Tasks.Task OnAfterSuccessAsync(
+            global::{settings.Namespace}.AutoSDKHookContext context);
+
+        /// <summary>
+        /// Runs after an error response or transport failure is observed.
+        /// </summary>
+        /// <param name=""context""></param>
+        global::System.Threading.Tasks.Task OnAfterErrorAsync(
+            global::{settings.Namespace}.AutoSDKHookContext context);
+    }}
+
+    /// <summary>
+    /// Convenience base type for request hooks with no-op defaults.
+    /// </summary>
+    public abstract class AutoSDKHook : global::{settings.Namespace}.IAutoSDKHook
+    {{
+        /// <inheritdoc />
+        public virtual global::System.Threading.Tasks.Task OnBeforeRequestAsync(
+            global::{settings.Namespace}.AutoSDKHookContext context)
+        {{
+            return global::System.Threading.Tasks.Task.CompletedTask;
+        }}
+
+        /// <inheritdoc />
+        public virtual global::System.Threading.Tasks.Task OnAfterSuccessAsync(
+            global::{settings.Namespace}.AutoSDKHookContext context)
+        {{
+            return global::System.Threading.Tasks.Task.CompletedTask;
+        }}
+
+        /// <inheritdoc />
+        public virtual global::System.Threading.Tasks.Task OnAfterErrorAsync(
+            global::{settings.Namespace}.AutoSDKHookContext context)
+        {{
+            return global::System.Threading.Tasks.Task.CompletedTask;
+        }}
+    }}
+
+    /// <summary>
+    /// Runtime metadata passed to generated SDK hooks.
+    /// </summary>
+    public sealed class AutoSDKHookContext
+    {{
+        /// <summary>
+        /// The source OpenAPI operation id or generated fallback id.
+        /// </summary>
+        public string OperationId {{ get; set; }} = string.Empty;
+
+        /// <summary>
+        /// The generated C# method name.
+        /// </summary>
+        public string MethodName {{ get; set; }} = string.Empty;
+
+        /// <summary>
+        /// The OpenAPI path template for the operation.
+        /// </summary>
+        public string PathTemplate {{ get; set; }} = string.Empty;
+
+        /// <summary>
+        /// The HTTP method used for the request.
+        /// </summary>
+        public string HttpMethod {{ get; set; }} = string.Empty;
+
+        /// <summary>
+        /// The client's resolved base URI.
+        /// </summary>
+        public global::System.Uri? BaseUri {{ get; set; }}
+
+        /// <summary>
+        /// The outgoing HTTP request for the current attempt.
+        /// </summary>
+        public global::System.Net.Http.HttpRequestMessage Request {{ get; set; }} = null!;
+
+        /// <summary>
+        /// The HTTP response when one was received.
+        /// </summary>
+        public global::System.Net.Http.HttpResponseMessage? Response {{ get; set; }}
+
+        /// <summary>
+        /// The transport or processing exception when one was observed.
+        /// </summary>
+        public global::System.Exception? Exception {{ get; set; }}
+
+        /// <summary>
+        /// The client-wide runtime options.
+        /// </summary>
+        public global::{settings.Namespace}.AutoSDKClientOptions ClientOptions {{ get; set; }} = null!;
+
+        /// <summary>
+        /// The per-request runtime options.
+        /// </summary>
+        public global::{settings.Namespace}.AutoSDKRequestOptions? RequestOptions {{ get; set; }}
+
+        /// <summary>
+        /// The current attempt number, starting at 1.
+        /// </summary>
+        public int Attempt {{ get; set; }}
+
+        /// <summary>
+        /// The total number of attempts allowed for this request.
+        /// </summary>
+        public int MaxAttempts {{ get; set; }}
+
+        /// <summary>
+        /// Indicates whether the generated client will retry after this hook invocation.
+        /// </summary>
+        public bool WillRetry {{ get; set; }}
+
+        /// <summary>
+        /// The effective cancellation token for the current request attempt.
+        /// </summary>
+        public global::System.Threading.CancellationToken CancellationToken {{ get; set; }}
+    }}
+
     internal static class AutoSDKRequestOptionsSupport
     {{
+        internal static global::{settings.Namespace}.AutoSDKHookContext CreateHookContext(
+            string operationId,
+            string methodName,
+            string pathTemplate,
+            string httpMethod,
+            global::System.Uri? baseUri,
+            global::System.Net.Http.HttpRequestMessage request,
+            global::System.Net.Http.HttpResponseMessage? response,
+            global::System.Exception? exception,
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::{settings.Namespace}.AutoSDKRequestOptions? requestOptions,
+            int attempt,
+            int maxAttempts,
+            bool willRetry,
+            global::System.Threading.CancellationToken cancellationToken)
+        {{
+            return new global::{settings.Namespace}.AutoSDKHookContext
+            {{
+                OperationId = operationId ?? string.Empty,
+                MethodName = methodName ?? string.Empty,
+                PathTemplate = pathTemplate ?? string.Empty,
+                HttpMethod = httpMethod ?? string.Empty,
+                BaseUri = baseUri,
+                Request = request,
+                Response = response,
+                Exception = exception,
+                ClientOptions = clientOptions,
+                RequestOptions = requestOptions,
+                Attempt = attempt,
+                MaxAttempts = maxAttempts,
+                WillRetry = willRetry,
+                CancellationToken = cancellationToken,
+            }};
+        }}
+
+        internal static global::System.Threading.Tasks.Task OnBeforeRequestAsync(
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::{settings.Namespace}.AutoSDKHookContext context)
+        {{
+            return InvokeHooksAsync(clientOptions, static (hook, hookContext) => hook.OnBeforeRequestAsync(hookContext), context);
+        }}
+
+        internal static global::System.Threading.Tasks.Task OnAfterSuccessAsync(
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::{settings.Namespace}.AutoSDKHookContext context)
+        {{
+            return InvokeHooksAsync(clientOptions, static (hook, hookContext) => hook.OnAfterSuccessAsync(hookContext), context);
+        }}
+
+        internal static global::System.Threading.Tasks.Task OnAfterErrorAsync(
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::{settings.Namespace}.AutoSDKHookContext context)
+        {{
+            return InvokeHooksAsync(clientOptions, static (hook, hookContext) => hook.OnAfterErrorAsync(hookContext), context);
+        }}
+
         internal static bool GetReadResponseAsString(
             global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
             global::{settings.Namespace}.AutoSDKRequestOptions? requestOptions,
@@ -240,6 +444,27 @@ namespace {settings.Namespace}
                 {{
                     request.Content.Headers.TryAddWithoutValidation(header.Key, header.Value ?? string.Empty);
                 }}
+            }}
+        }}
+
+        private static async global::System.Threading.Tasks.Task InvokeHooksAsync(
+            global::{settings.Namespace}.AutoSDKClientOptions clientOptions,
+            global::System.Func<global::{settings.Namespace}.IAutoSDKHook, global::{settings.Namespace}.AutoSDKHookContext, global::System.Threading.Tasks.Task> callback,
+            global::{settings.Namespace}.AutoSDKHookContext context)
+        {{
+            if (clientOptions.Hooks == null || clientOptions.Hooks.Count == 0)
+            {{
+                return;
+            }}
+
+            foreach (var hook in clientOptions.Hooks)
+            {{
+                if (hook == null)
+                {{
+                    continue;
+                }}
+
+                await callback(hook, context).ConfigureAwait(false);
             }}
         }}
     }}

--- a/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
+++ b/src/tests/AutoSDK.IntegrationTests.Cli/CliTests.cs
@@ -304,11 +304,16 @@ public class CliTests
 
                 combinedSource.Should().Contain("public sealed class AutoSDKClientOptions");
                 combinedSource.Should().Contain("public sealed class AutoSDKRequestOptions");
+                combinedSource.Should().Contain("public interface IAutoSDKHook");
+                combinedSource.Should().Contain("public sealed class AutoSDKHookContext");
                 combinedSource.Should().Contain("global::Generated.Options.AutoSDKClientOptions? options = null");
                 combinedSource.Should().Contain("global::Generated.Options.AutoSDKRequestOptions? requestOptions = default");
                 combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.AppendQueryParameters(");
                 combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.ApplyHeaders(");
                 combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.GetMaxAttempts(");
+                combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.OnBeforeRequestAsync(");
+                combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.OnAfterSuccessAsync(");
+                combinedSource.Should().Contain("AutoSDKRequestOptionsSupport.OnAfterErrorAsync(");
             });
     }
 

--- a/src/tests/AutoSDK.UnitTests/RequestOptionsGenerationTests.cs
+++ b/src/tests/AutoSDK.UnitTests/RequestOptionsGenerationTests.cs
@@ -54,6 +54,10 @@ public class RequestOptionsGenerationTests
         supportSource.Should().Contain("public sealed class AutoSDKClientOptions");
         supportSource.Should().Contain("public sealed class AutoSDKRequestOptions");
         supportSource.Should().Contain("public sealed class AutoSDKRetryOptions");
+        supportSource.Should().Contain("public interface IAutoSDKHook");
+        supportSource.Should().Contain("public sealed class AutoSDKHookContext");
+        supportSource.Should().Contain("public global::System.Collections.Generic.List<global::G.IAutoSDKHook> Hooks { get; }");
+        supportSource.Should().Contain("public global::G.AutoSDKClientOptions AddHook(");
     }
 
     [TestMethod]
@@ -96,6 +100,10 @@ public class RequestOptionsGenerationTests
         methodSource.Should().Contain("AutoSDKRequestOptionsSupport.CreateTimeoutCancellationTokenSource(");
         methodSource.Should().Contain("AutoSDKRequestOptionsSupport.GetMaxAttempts(");
         methodSource.Should().Contain("AutoSDKRequestOptionsSupport.ShouldRetryStatusCode(__response.StatusCode)");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.OnBeforeRequestAsync(");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.OnAfterSuccessAsync(");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.OnAfterErrorAsync(");
+        methodSource.Should().Contain("AutoSDKRequestOptionsSupport.CreateHookContext(");
         methodSource.Should().Contain("if (__effectiveReadResponseAsString)");
     }
 }


### PR DESCRIPTION
Closes #240

## Summary
- add generated SDK hook interfaces and hook context support to client options
- invoke hooks before requests, after successful responses, and after failures with retry metadata
- cover the generated surface with unit, CLI integration, and snapshot tests

## Validation
- dotnet build src/libs/AutoSDK.CSharp/AutoSDK.CSharp.csproj /p:TreatWarningsAsErrors=true
- dotnet build src/libs/AutoSDK.CLI/AutoSDK.CLI.csproj /p:TreatWarningsAsErrors=true
- dotnet test src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj --filter "FullyQualifiedName~RequestOptionsGenerationTests"
- dotnet test src/tests/AutoSDK.IntegrationTests.Cli/AutoSDK.IntegrationTests.Cli.csproj --filter "FullyQualifiedName~Generate_WithRequestAndClientOptions_EmitsOptionsSupportAndBuilds"
- dotnet test src/tests/AutoSDK.SnapshotTests/AutoSDK.SnapshotTests.csproj --filter "FullyQualifiedName~SdkGenerator_MethodsProject_EmitsRequiredSupportSources"