### PR TITLE
fix(generator): document server selection support

### DIFF
--- a/src/libs/AutoSDK.CSharp/Sources/Sources.ServerSelection.cs
+++ b/src/libs/AutoSDK.CSharp/Sources/Sources.ServerSelection.cs
@@ -17,6 +17,13 @@ namespace {settings.Namespace}
     /// </summary>
     public sealed class AutoSDKServer
     {{
+        /// <summary>
+        /// Initializes a new instance of the <see cref=""AutoSDKServer""/> class.
+        /// </summary>
+        /// <param name=""id"">The stable identifier for this server option.</param>
+        /// <param name=""name"">The display name for this server option.</param>
+        /// <param name=""url"">The server URL.</param>
+        /// <param name=""description"">The server description.</param>
         public AutoSDKServer(
             string id,
             string name,
@@ -30,10 +37,25 @@ namespace {settings.Namespace}
             Uri = new global::System.Uri(url, global::System.UriKind.RelativeOrAbsolute);
         }}
 
+        /// <summary>
+        /// Gets the stable identifier for this server option.
+        /// </summary>
         public string Id {{ get; }}
+        /// <summary>
+        /// Gets the display name for this server option.
+        /// </summary>
         public string Name {{ get; }}
+        /// <summary>
+        /// Gets the server URL.
+        /// </summary>
         public string Url {{ get; }}
+        /// <summary>
+        /// Gets the server description.
+        /// </summary>
         public string Description {{ get; }}
+        /// <summary>
+        /// Gets the parsed server URI.
+        /// </summary>
         public global::System.Uri Uri {{ get; }}
     }}
 


### PR DESCRIPTION
## Summary\n- add XML docs to generated server selection support\n- fix CS1591 failures in generated projects that treat warnings as errors\n- restore green CI for the runtime server selection merge on main\n\n## Testing\n- dotnet run --framework net10.0 --project src/libs/AutoSDK.CLI init TestSolution TestApi https://raw.githubusercontent.com/api/openapi.json TestCompany --output TestProject --add-tests false\n- dotnet run --framework net10.0 --project src/libs/AutoSDK.CLI generate specs/instill.yaml --namespace TestSolution --targetFramework net10.0 --output TestProject/src/libs/TestSolution/Generated --ignore-openapi-errors\n- dotnet build TestProject /p:TreatWarningsAsErrors=true\n- dotnet test src/tests/AutoSDK.UnitTests/AutoSDK.UnitTests.csproj --filter "FullyQualifiedName~ServerSelectionTests|FullyQualifiedName~NamingTests.Methods"\n- dotnet test src/tests/AutoSDK.IntegrationTests.Cli/AutoSDK.IntegrationTests.Cli.csproj --filter "FullyQualifiedName~Generate_WithServerVariableDefaults_UsesResolvedBaseUrl"